### PR TITLE
Parvathy | GOK-181 | Fix. Variable frequency as default

### DIFF
--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -129,7 +129,7 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
         this.effectiveStartDate = this.effectiveStartDate || this.encounterDate;
     }
 
-    this.isUniformFrequency = true;
+    this.isUniformFrequency = false;
     this.showExtraInfo = false;
 
     this.overlappingScheduledWith = function (otherDrugOrder) {

--- a/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
+++ b/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
@@ -1053,7 +1053,7 @@ describe("drugOrderViewModel", function () {
                     doseUnits: "Some"
                 };
 
-                expect(treatment.isUniformDoseRequired()).toBeTruthy();
+                expect(treatment.isUniformDoseRequired()).toBeFalsy();
             });
 
 
@@ -1074,7 +1074,7 @@ describe("drugOrderViewModel", function () {
                     doseUnits: "Some"
                 };
 
-                expect(treatment.isUniformDoseRequired()).toBeTruthy();
+                expect(treatment.isUniformDoseRequired()).toBeFalsy();
             });
 
             it("should not throw validation error when route is present in routesToMakeDoseSectionNonMandatory but units are defaulted", function () {
@@ -1101,7 +1101,7 @@ describe("drugOrderViewModel", function () {
                 treatment.uniformDosingType.dose = undefined;
                 treatment.uniformDosingType.doseUnits = "ml";
 
-                expect(treatment.isMantissaRequired()).toBeTruthy();
+                expect(treatment.isMantissaRequired()).toBeFalsy();
 
                 treatmentConfig.inputOptionsConfig.routesToMakeDoseSectionNonMandatory = ["Topical", "Inhalation"];
                 var treatment = sampleTreatment(treatmentConfig, null, Bahmni.Common.Util.DateUtil.now());


### PR DESCRIPTION
Under medications tab, by default uniform frequency template is shown as default and we need to   click on the toggle button to change it to variable frequency template. 
<img width="1395" alt="Screenshot 2023-07-10 at 2 36 53 PM" src="https://github.com/Bahmni-HWC/openmrs-module-bahmniapps/assets/102500787/f3c7b249-8106-4f86-a86a-b60ce685823b">

But since, variable frequency is more user friendly we wanted that as the default one. So, In this PR this is handled and now by default the screen looks like this
<img width="1403" alt="Screenshot 2023-07-10 at 2 37 23 PM" src="https://github.com/Bahmni-HWC/openmrs-module-bahmniapps/assets/102500787/c1f11a80-0cc8-4394-bb9b-22ad06fdea4e">
