### PR TITLE
GOK-277 | Fix. Chief Complaint Record Display Format

### DIFF
--- a/ui/app/clinical/consultation/mappers/specimenMapper.js
+++ b/ui/app/clinical/consultation/mappers/specimenMapper.js
@@ -1,7 +1,7 @@
 'use strict';
 
 Bahmni.Clinical.SpecimenMapper = function () {
-    this.mapObservationToSpecimen = function (observation, allSamples, conceptsConfig, dontSortByObsDateTime) {
+    this.mapObservationToSpecimen = function (observation, allSamples, conceptsConfig, dontSortByObsDateTime, $translate) {
         var specimen = new Bahmni.Clinical.Specimen(observation, allSamples);
         specimen.specimenId = specimen.identifier;
         specimen.specimenSource = specimen.type.shortName ? specimen.type.shortName : specimen.type.name;
@@ -10,7 +10,7 @@ Bahmni.Clinical.SpecimenMapper = function () {
         if (specimen.report && specimen.report.results) {
             specimen.report.results = (specimen.report.results) instanceof Array ? specimen.report.results : [specimen.report.results];
 
-            var obs = new Bahmni.Common.Obs.ObservationMapper().map(specimen.report.results, conceptsConfig, dontSortByObsDateTime);
+            var obs = new Bahmni.Common.Obs.ObservationMapper().map(specimen.report.results, conceptsConfig, dontSortByObsDateTime, $translate);
             specimen.sampleResult = obs && obs.length > 0 ? obs[0] : obs;
         }
         if (specimen.sample && specimen.sample.additionalAttributes) {

--- a/ui/app/common/concept-set/mappers/observationMapper.js
+++ b/ui/app/common/concept-set/mappers/observationMapper.js
@@ -200,166 +200,166 @@ Bahmni.ConceptSet.ObservationMapper = function () {
     }
 
     var mapObservationGroupMembers = function (observations, parentConcept, conceptSetConfig) {
-      var observationGroupMembers = [];
-      var conceptSetMembers = parentConcept.setMembers;
-      conceptSetMembers.forEach(function (memberConcept) {
-          var savedObservations = findInSavedObservation(memberConcept, observations);
-          var configForConcept = conceptSetConfig[memberConcept.name.name] || {};
-          var numberOfNodes = configForConcept.multiple || 1;
-          for (var i = savedObservations.length - 1; i >= 0; i--) {
-              observationGroupMembers.push(mapObservation(memberConcept, savedObservations[i], conceptSetConfig, parentConcept));
-          }
-          for (var i = 0; i < numberOfNodes - savedObservations.length; i++) {
-              observationGroupMembers.push(mapObservation(memberConcept, null, conceptSetConfig, parentConcept));
-          }
-      });
-      return observationGroupMembers;
-  };
+        var observationGroupMembers = [];
+        var conceptSetMembers = parentConcept.setMembers;
+        conceptSetMembers.forEach(function (memberConcept) {
+            var savedObservations = findInSavedObservation(memberConcept, observations);
+            var configForConcept = conceptSetConfig[memberConcept.name.name] || {};
+            var numberOfNodes = configForConcept.multiple || 1;
+            for (var i = savedObservations.length - 1; i >= 0; i--) {
+                observationGroupMembers.push(mapObservation(memberConcept, savedObservations[i], conceptSetConfig, parentConcept));
+            }
+            for (var i = 0; i < numberOfNodes - savedObservations.length; i++) {
+                observationGroupMembers.push(mapObservation(memberConcept, null, conceptSetConfig, parentConcept));
+            }
+        });
+        return observationGroupMembers;
+    };
 
-  var getDatatype = function (concept) {
-      if (concept.dataType) {
-          return concept.dataType;
-      }
-      return concept.datatype && concept.datatype.name;
-  };
+    var getDatatype = function (concept) {
+        if (concept.dataType) {
+            return concept.dataType;
+        }
+        return concept.datatype && concept.datatype.name;
+    };
 
 // tODO : remove conceptUIConfig
-  var newObservation = function (concept, savedObs, conceptSetConfig, mappedGroupMembers) {
-      var observation = buildObservation(concept, savedObs, mappedGroupMembers);
-      var obs = new Bahmni.ConceptSet.Observation(observation, savedObs, conceptSetConfig, mappedGroupMembers);
-      if (getDatatype(concept) === "Boolean") {
-          obs = new Bahmni.ConceptSet.BooleanObservation(obs, conceptSetConfig);
-      }
-      return obs;
-  };
+    var newObservation = function (concept, savedObs, conceptSetConfig, mappedGroupMembers) {
+        var observation = buildObservation(concept, savedObs, mappedGroupMembers);
+        var obs = new Bahmni.ConceptSet.Observation(observation, savedObs, conceptSetConfig, mappedGroupMembers);
+        if (getDatatype(concept) === "Boolean") {
+            obs = new Bahmni.ConceptSet.BooleanObservation(obs, conceptSetConfig);
+        }
+        return obs;
+    };
 
 // TODO : remove conceptUIConfig
-  var newObservationNode = function (concept, savedObsNode, conceptSetConfig, mappedGroupMembers) {
-      var observation = buildObservation(concept, savedObsNode, mappedGroupMembers);
-      return new Bahmni.ConceptSet.ObservationNode(observation, savedObsNode, conceptSetConfig, concept);
-  };
+    var newObservationNode = function (concept, savedObsNode, conceptSetConfig, mappedGroupMembers) {
+        var observation = buildObservation(concept, savedObsNode, mappedGroupMembers);
+        return new Bahmni.ConceptSet.ObservationNode(observation, savedObsNode, conceptSetConfig, concept);
+    };
 
-  var showAddMoreButton = function (rootObservation) {
-      var observation = this;
-      var lastObservationByLabel = _.findLast(rootObservation.groupMembers, {
-          label: observation.label
-      });
-      return lastObservationByLabel.uuid === observation.uuid;
-  };
+    var showAddMoreButton = function (rootObservation) {
+        var observation = this;
+        var lastObservationByLabel = _.findLast(rootObservation.groupMembers, {
+            label: observation.label
+        });
+        return lastObservationByLabel.uuid === observation.uuid;
+    };
 
-  function buildObservation (concept, savedObs, mappedGroupMembers) {
-      var comment = savedObs ? savedObs.comment : null;
-      return {
-          concept: conceptMapper.map(concept),
-          units: concept.units,
-          label: getLabel(concept),
-          possibleAnswers: concept.answers,
-          groupMembers: mappedGroupMembers,
-          comment: comment,
-          showAddMoreButton: showAddMoreButton
-      };
-  }
+    function buildObservation (concept, savedObs, mappedGroupMembers) {
+        var comment = savedObs ? savedObs.comment : null;
+        return {
+            concept: conceptMapper.map(concept),
+            units: concept.units,
+            label: getLabel(concept),
+            possibleAnswers: concept.answers,
+            groupMembers: mappedGroupMembers,
+            comment: comment,
+            showAddMoreButton: showAddMoreButton
+        };
+    }
 
-  var createObservationForDisplay = function (observation, concept, $translate) {
-      if (observation.value == null) {
-          return;
-      }
-      var observationValue = getObservationDisplayValue(observation);
-      observationValue = observation.durationObs ? getDurationDisplayValue(observationValue, observation.durationObs, $translate) : observationValue;
-      return {
-          value: observationValue,
-          abnormalObs: observation.abnormalObs,
-          duration: observation.durationObs,
-          provider: observation.provider,
-          label: getLabel(observation.concept),
-          observationDateTime: observation.observationDateTime,
-          concept: concept,
-          comment: observation.comment,
-          uuid: observation.uuid
-      };
-  };
+    var createObservationForDisplay = function (observation, concept, $translate) {
+        if (observation.value == null) {
+            return;
+        }
+        var observationValue = getObservationDisplayValue(observation);
+        observationValue = observation.durationObs ? getDurationDisplayValue(observationValue, observation.durationObs, $translate) : observationValue;
+        return {
+            value: observationValue,
+            abnormalObs: observation.abnormalObs,
+            duration: observation.durationObs,
+            provider: observation.provider,
+            label: getLabel(observation.concept),
+            observationDateTime: observation.observationDateTime,
+            concept: concept,
+            comment: observation.comment,
+            uuid: observation.uuid
+        };
+    };
 
-  var getObservationDisplayValue = function (observation) {
-      if (observation.isBoolean || observation.type === "Boolean") {
-          return observation.value === true ? "Yes" : "No";
-      }
-      if (!observation.value) {
-          return "";
-      }
-      if (typeof observation.value.name === "object") {
-          var valueConcept = conceptMapper.map(observation.value);
-          return valueConcept.shortName || valueConcept.name;
-      }
-      return (observation.value.shortName || observation.value.name || observation.value);
-  };
+    var getObservationDisplayValue = function (observation) {
+        if (observation.isBoolean || observation.type === "Boolean") {
+            return observation.value === true ? "Yes" : "No";
+        }
+        if (!observation.value) {
+            return "";
+        }
+        if (typeof observation.value.name === "object") {
+            var valueConcept = conceptMapper.map(observation.value);
+            return valueConcept.shortName || valueConcept.name;
+        }
+        return (observation.value.shortName || observation.value.name || observation.value);
+    };
 
-  var getObservationValue = function (groupMembers, $translate) {
-      var chiefComplaint = "";
-      var chiefComplaintText = "";
-      var symptomDuration = "";
-      var durationUnit = "";
-      _.forEach(groupMembers, function (member) {
-          if (member && member.has($translate.instant("CHIEF_COMPLAINT_CODED_KEY"))) {
-              chiefComplaint = member.get($translate.instant("CHIEF_COMPLAINT_CODED_KEY"));
-          }
-          if (member && member.has($translate.instant("CHIEF_COMPLAINT_TEXT_KEY"))) {
-              chiefComplaintText = member.get($translate.instant("CHIEF_COMPLAINT_TEXT_KEY"));
-          }
-          if (member && member.has($translate.instant("SIGN_SYMPTOM_DURATION_KEY"))) {
-              symptomDuration = member.get($translate.instant("SIGN_SYMPTOM_DURATION_KEY"));
-          }
-          if (member && member.has($translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY"))) {
-              durationUnit = member.get($translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY"));
-          }
-      });
-      return getChiefComplaintDisplayValue(chiefComplaint, chiefComplaintText, symptomDuration, durationUnit, $translate);
-  };
+    var getObservationValue = function (groupMembers, $translate) {
+        var chiefComplaint = "";
+        var chiefComplaintText = "";
+        var symptomDuration = "";
+        var durationUnit = "";
+        _.forEach(groupMembers, function (member) {
+            if (member && member.has($translate.instant("CHIEF_COMPLAINT_CODED_KEY"))) {
+                chiefComplaint = member.get($translate.instant("CHIEF_COMPLAINT_CODED_KEY"));
+            }
+            if (member && member.has($translate.instant("CHIEF_COMPLAINT_TEXT_KEY"))) {
+                chiefComplaintText = member.get($translate.instant("CHIEF_COMPLAINT_TEXT_KEY"));
+            }
+            if (member && member.has($translate.instant("SIGN_SYMPTOM_DURATION_KEY"))) {
+                symptomDuration = member.get($translate.instant("SIGN_SYMPTOM_DURATION_KEY"));
+            }
+            if (member && member.has($translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY"))) {
+                durationUnit = member.get($translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY"));
+            }
+        });
+        return getChiefComplaintDisplayValue(chiefComplaint, chiefComplaintText, symptomDuration, durationUnit, $translate);
+    };
 
-  var getGroupMemberValue = function (observation, $translate) {
-      const chiefComplaintCoded = $translate.instant("CHIEF_COMPLAINT_CODED_KEY");
-      const chiefComplaintText = $translate.instant("CHIEF_COMPLAINT_TEXT_KEY");
-      const symptomDuration = $translate.instant("SIGN_SYMPTOM_DURATION_KEY");
-      const durationUnit = $translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY");
-      if (typeof observation.concept === "object" && observation.concept.name === chiefComplaintCoded) {
-          if (observation.value.name === $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
-              return new Map().set(chiefComplaintCoded, observation.value.name);
-          }
-          return new Map().set(chiefComplaintCoded, getObservationDisplayValue(observation));
-      }
-      if (typeof observation.concept === "object" && observation.concept.name === chiefComplaintText) {
-          return new Map().set(chiefComplaintText, getObservationDisplayValue(observation));
-      }
-      if (typeof observation.concept === "object" && observation.concept.name === symptomDuration) {
-          return new Map().set(symptomDuration, getObservationDisplayValue(observation));
-      }
-      if (typeof observation.concept === "object" && observation.concept.name === durationUnit) {
-          return new Map().set(durationUnit, getObservationDisplayValue(observation));
-      }
-  };
+    var getGroupMemberValue = function (observation, $translate) {
+        const chiefComplaintCoded = $translate.instant("CHIEF_COMPLAINT_CODED_KEY");
+        const chiefComplaintText = $translate.instant("CHIEF_COMPLAINT_TEXT_KEY");
+        const symptomDuration = $translate.instant("SIGN_SYMPTOM_DURATION_KEY");
+        const durationUnit = $translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY");
+        if (typeof observation.concept === "object" && observation.concept.name === chiefComplaintCoded) {
+            if (observation.value.name === $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
+                return new Map().set(chiefComplaintCoded, observation.value.name);
+            }
+            return new Map().set(chiefComplaintCoded, getObservationDisplayValue(observation));
+        }
+        if (typeof observation.concept === "object" && observation.concept.name === chiefComplaintText) {
+            return new Map().set(chiefComplaintText, getObservationDisplayValue(observation));
+        }
+        if (typeof observation.concept === "object" && observation.concept.name === symptomDuration) {
+            return new Map().set(symptomDuration, getObservationDisplayValue(observation));
+        }
+        if (typeof observation.concept === "object" && observation.concept.name === durationUnit) {
+            return new Map().set(durationUnit, getObservationDisplayValue(observation));
+        }
+    };
 
-  var getChiefComplaintDisplayValue = function (chiefComplaint, chiefComplaintText, symptomDuration, durationUnit, $translate) {
-      if (chiefComplaint !== $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
-          return $translate.instant("CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: chiefComplaint, duration: symptomDuration, unit: durationUnit});
-      } else {
-          return $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: chiefComplaint, chiefComplaintText: chiefComplaintText, duration: symptomDuration, unit: durationUnit});
-      }
-  };
+    var getChiefComplaintDisplayValue = function (chiefComplaint, chiefComplaintText, symptomDuration, durationUnit, $translate) {
+        if (chiefComplaint !== $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
+            return $translate.instant("CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: chiefComplaint, duration: symptomDuration, unit: durationUnit});
+        } else {
+            return $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: chiefComplaint, chiefComplaintText: chiefComplaintText, duration: symptomDuration, unit: durationUnit});
+        }
+    };
 
-  var getDurationDisplayValue = function (chiefComplaint, duration, $translate) {
-      var durationForDisplay = Bahmni.Common.Util.DateUtil.convertToUnits(duration.value);
-      if (durationForDisplay["value"] && durationForDisplay["unitName"]) {
-          return getChiefComplaintDisplayValue(chiefComplaint, durationForDisplay["value"], durationForDisplay["unitName"], $translate);
-      }
-      return "";
-  };
+    var getDurationDisplayValue = function (chiefComplaint, duration, $translate) {
+        var durationForDisplay = Bahmni.Common.Util.DateUtil.convertToUnits(duration.value);
+        if (durationForDisplay["value"] && durationForDisplay["unitName"]) {
+            return getChiefComplaintDisplayValue(chiefComplaint, durationForDisplay["value"], durationForDisplay["unitName"], $translate);
+        }
+        return "";
+    };
 
-  this.getGridObservationDisplayValue = function (observation, $translate) {
-      var memberValues = _.compact(_.map(observation.groupMembers, function (member) { return getGroupMemberValue(member, $translate); }));
-      return getObservationValue(memberValues, $translate);
-  };
+    this.getGridObservationDisplayValue = function (observation, $translate) {
+        var memberValues = _.compact(_.map(observation.groupMembers, function (member) { return getGroupMemberValue(member, $translate); }));
+        return getObservationValue(memberValues, $translate);
+    };
 
-  var getLabel = function (concept) {
-      var mappedConcept = conceptMapper.map(concept);
-      return mappedConcept.shortName || mappedConcept.name;
-  };
+    var getLabel = function (concept) {
+        var mappedConcept = conceptMapper.map(concept);
+        return mappedConcept.shortName || mappedConcept.name;
+    };
 };

--- a/ui/app/common/concept-set/mappers/observationMapper.js
+++ b/ui/app/common/concept-set/mappers/observationMapper.js
@@ -199,265 +199,167 @@ Bahmni.ConceptSet.ObservationMapper = function () {
         }
     }
 
-    var mapObservationGroupMembers = function (
-    observations,
-    parentConcept,
-    conceptSetConfig
-  ) {
-        var observationGroupMembers = [];
-        var conceptSetMembers = parentConcept.setMembers;
-        conceptSetMembers.forEach(function (memberConcept) {
-            var savedObservations = findInSavedObservation(
-        memberConcept,
-        observations
-      );
-            var configForConcept = conceptSetConfig[memberConcept.name.name] || {};
-            var numberOfNodes = configForConcept.multiple || 1;
-            for (var i = savedObservations.length - 1; i >= 0; i--) {
-                observationGroupMembers.push(
-          mapObservation(
-            memberConcept,
-            savedObservations[i],
-            conceptSetConfig,
-            parentConcept
-          )
-        );
-            }
-            for (var i = 0; i < numberOfNodes - savedObservations.length; i++) {
-                observationGroupMembers.push(
-          mapObservation(memberConcept, null, conceptSetConfig, parentConcept)
-        );
-            }
-        });
-        return observationGroupMembers;
-    };
+    var mapObservationGroupMembers = function (observations, parentConcept, conceptSetConfig) {
+      var observationGroupMembers = [];
+      var conceptSetMembers = parentConcept.setMembers;
+      conceptSetMembers.forEach(function (memberConcept) {
+          var savedObservations = findInSavedObservation(memberConcept, observations);
+          var configForConcept = conceptSetConfig[memberConcept.name.name] || {};
+          var numberOfNodes = configForConcept.multiple || 1;
+          for (var i = savedObservations.length - 1; i >= 0; i--) {
+              observationGroupMembers.push(mapObservation(memberConcept, savedObservations[i], conceptSetConfig, parentConcept));
+          }
+          for (var i = 0; i < numberOfNodes - savedObservations.length; i++) {
+              observationGroupMembers.push(mapObservation(memberConcept, null, conceptSetConfig, parentConcept));
+          }
+      });
+      return observationGroupMembers;
+  };
 
-    var getDatatype = function (concept) {
-        if (concept.dataType) {
-            return concept.dataType;
-        }
-        return concept.datatype && concept.datatype.name;
-    };
+  var getDatatype = function (concept) {
+      if (concept.dataType) {
+          return concept.dataType;
+      }
+      return concept.datatype && concept.datatype.name;
+  };
 
-  // tODO : remove conceptUIConfig
-    var newObservation = function (
-    concept,
-    savedObs,
-    conceptSetConfig,
-    mappedGroupMembers
-  ) {
-        var observation = buildObservation(concept, savedObs, mappedGroupMembers);
-        var obs = new Bahmni.ConceptSet.Observation(
-      observation,
-      savedObs,
-      conceptSetConfig,
-      mappedGroupMembers
-    );
-        if (getDatatype(concept) === "Boolean") {
-            obs = new Bahmni.ConceptSet.BooleanObservation(obs, conceptSetConfig);
-        }
-        return obs;
-    };
+// tODO : remove conceptUIConfig
+  var newObservation = function (concept, savedObs, conceptSetConfig, mappedGroupMembers) {
+      var observation = buildObservation(concept, savedObs, mappedGroupMembers);
+      var obs = new Bahmni.ConceptSet.Observation(observation, savedObs, conceptSetConfig, mappedGroupMembers);
+      if (getDatatype(concept) === "Boolean") {
+          obs = new Bahmni.ConceptSet.BooleanObservation(obs, conceptSetConfig);
+      }
+      return obs;
+  };
 
-  // TODO : remove conceptUIConfig
-    var newObservationNode = function (
-    concept,
-    savedObsNode,
-    conceptSetConfig,
-    mappedGroupMembers
-  ) {
-        var observation = buildObservation(
-      concept,
-      savedObsNode,
-      mappedGroupMembers
-    );
-        return new Bahmni.ConceptSet.ObservationNode(
-      observation,
-      savedObsNode,
-      conceptSetConfig,
-      concept
-    );
-    };
+// TODO : remove conceptUIConfig
+  var newObservationNode = function (concept, savedObsNode, conceptSetConfig, mappedGroupMembers) {
+      var observation = buildObservation(concept, savedObsNode, mappedGroupMembers);
+      return new Bahmni.ConceptSet.ObservationNode(observation, savedObsNode, conceptSetConfig, concept);
+  };
 
-    var showAddMoreButton = function (rootObservation) {
-        var observation = this;
-        var lastObservationByLabel = _.findLast(rootObservation.groupMembers, {
-            label: observation.label
-        });
-        return lastObservationByLabel.uuid === observation.uuid;
-    };
+  var showAddMoreButton = function (rootObservation) {
+      var observation = this;
+      var lastObservationByLabel = _.findLast(rootObservation.groupMembers, {
+          label: observation.label
+      });
+      return lastObservationByLabel.uuid === observation.uuid;
+  };
 
-    function buildObservation (concept, savedObs, mappedGroupMembers) {
-        var comment = savedObs ? savedObs.comment : null;
-        return {
-            concept: conceptMapper.map(concept),
-            units: concept.units,
-            label: getLabel(concept),
-            possibleAnswers: concept.answers,
-            groupMembers: mappedGroupMembers,
-            comment: comment,
-            showAddMoreButton: showAddMoreButton
-        };
-    }
+  function buildObservation (concept, savedObs, mappedGroupMembers) {
+      var comment = savedObs ? savedObs.comment : null;
+      return {
+          concept: conceptMapper.map(concept),
+          units: concept.units,
+          label: getLabel(concept),
+          possibleAnswers: concept.answers,
+          groupMembers: mappedGroupMembers,
+          comment: comment,
+          showAddMoreButton: showAddMoreButton
+      };
+  }
 
-    var createObservationForDisplay = function (
-    observation,
-    concept,
-    $translate
-  ) {
-        if (observation.value == null) {
-            return;
-        }
-        var observationValue = getObservationDisplayValue(observation);
-        observationValue = observation.durationObs
-      ? getDurationDisplayValue(
-          observationValue,
-          observation.durationObs,
-          $translate
-        )
-      : observationValue;
-        return {
-            value: observationValue,
-            abnormalObs: observation.abnormalObs,
-            duration: observation.durationObs,
-            provider: observation.provider,
-            label: getLabel(observation.concept),
-            observationDateTime: observation.observationDateTime,
-            concept: concept,
-            comment: observation.comment,
-            uuid: observation.uuid
-        };
-    };
+  var createObservationForDisplay = function (observation, concept, $translate) {
+      if (observation.value == null) {
+          return;
+      }
+      var observationValue = getObservationDisplayValue(observation);
+      observationValue = observation.durationObs ? getDurationDisplayValue(observationValue, observation.durationObs, $translate) : observationValue;
+      return {
+          value: observationValue,
+          abnormalObs: observation.abnormalObs,
+          duration: observation.durationObs,
+          provider: observation.provider,
+          label: getLabel(observation.concept),
+          observationDateTime: observation.observationDateTime,
+          concept: concept,
+          comment: observation.comment,
+          uuid: observation.uuid
+      };
+  };
 
-    var getObservationDisplayValue = function (observation) {
-        if (observation.isBoolean || observation.type === "Boolean") {
-            return observation.value === true ? "Yes" : "No";
-        }
-        if (!observation.value) {
-            return "";
-        }
-        if (typeof observation.value.name === "object") {
-            var valueConcept = conceptMapper.map(observation.value);
-            return valueConcept.shortName || valueConcept.name;
-        }
-        return (
-      observation.value.shortName || observation.value.name || observation.value
-        );
-    };
-    var getObservationValue = function (groupMembers, $translate) {
-        var chiefComplaint = "";
-        var symptomDuration = "";
-        var durationUnit = "";
-        _.forEach(groupMembers, function (member) {
-            if (
-        member &&
-        member.has($translate.instant("CHIEF_COMPLAINT_CODED_KEY"))
-      ) {
-                chiefComplaint = member.get(
-          $translate.instant("CHIEF_COMPLAINT_CODED_KEY")
-        );
-            }
-            if (
-        member &&
-        member.has($translate.instant("SIGN_SYMPTOM_DURATION_KEY"))
-      ) {
-                symptomDuration = member.get(
-          $translate.instant("SIGN_SYMPTOM_DURATION_KEY")
-        );
-            }
-            if (
-        member &&
-        member.has($translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY"))
-      ) {
-                durationUnit = member.get(
-          $translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY")
-        );
-            }
-        });
-        return getChiefComplaintDisplayValue(
-      chiefComplaint,
-      symptomDuration,
-      durationUnit,
-      $translate
-    );
-    };
-    var getGroupMemberValue = function (observation, $translate) {
-        const chiefComplaintCoded = $translate.instant("CHIEF_COMPLAINT_CODED_KEY");
-        const symptomDuration = $translate.instant("SIGN_SYMPTOM_DURATION_KEY");
-        const durationUnit = $translate.instant(
-      "CHIEF_COMPLAINT_DURATION_UNIT_KEY"
-    );
-        if (
-      typeof observation.concept === "object" &&
-      observation.concept.name === chiefComplaintCoded
-    ) {
-            return new Map().set(
-        chiefComplaintCoded,
-        getObservationDisplayValue(observation)
-      );
-        }
-        if (
-      typeof observation.concept === "object" &&
-      observation.concept.name === symptomDuration
-    ) {
-            return new Map().set(
-        symptomDuration,
-        getObservationDisplayValue(observation)
-      );
-        }
-        if (
-      typeof observation.concept === "object" &&
-      observation.concept.name === durationUnit
-    ) {
-            return new Map().set(
-        durationUnit,
-        getObservationDisplayValue(observation)
-      );
-        }
-    };
-    var getChiefComplaintDisplayValue = function (
-    chiefComplaint,
-    symptomDuration,
-    durationUnit,
-    $translate
-  ) {
-        return $translate.instant(
-      "CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY",
-            {
-                chiefComplaint: chiefComplaint,
-                duration: symptomDuration,
-                unit: durationUnit
-            }
-    );
-    };
-    var getDurationDisplayValue = function (
-    chiefComplaint,
-    duration,
-    $translate
-  ) {
-        var durationForDisplay = Bahmni.Common.Util.DateUtil.convertToUnits(
-      duration.value
-    );
-        if (durationForDisplay["value"] && durationForDisplay["unitName"]) {
-            return getChiefComplaintDisplayValue(
-        chiefComplaint,
-        durationForDisplay["value"],
-        durationForDisplay["unitName"],
-        $translate
-      );
-        }
-        return "";
-    };
-    this.getGridObservationDisplayValue = function (observation, $translate) {
-        var memberValues = _.compact(
-      _.map(observation.groupMembers, function (member) {
-          return getGroupMemberValue(member, $translate);
-      })
-    );
-        return getObservationValue(memberValues, $translate);
-    };
-    var getLabel = function (concept) {
-        var mappedConcept = conceptMapper.map(concept);
-        return mappedConcept.shortName || mappedConcept.name;
-    };
+  var getObservationDisplayValue = function (observation) {
+      if (observation.isBoolean || observation.type === "Boolean") {
+          return observation.value === true ? "Yes" : "No";
+      }
+      if (!observation.value) {
+          return "";
+      }
+      if (typeof observation.value.name === "object") {
+          var valueConcept = conceptMapper.map(observation.value);
+          return valueConcept.shortName || valueConcept.name;
+      }
+      return (observation.value.shortName || observation.value.name || observation.value);
+  };
+
+  var getObservationValue = function (groupMembers, $translate) {
+      var chiefComplaint = "";
+      var chiefComplaintText = "";
+      var symptomDuration = "";
+      var durationUnit = "";
+      _.forEach(groupMembers, function (member) {
+          if (member && member.has($translate.instant("CHIEF_COMPLAINT_CODED_KEY"))) {
+              chiefComplaint = member.get($translate.instant("CHIEF_COMPLAINT_CODED_KEY"));
+          }
+          if (member && member.has($translate.instant("CHIEF_COMPLAINT_TEXT_KEY"))) {
+              chiefComplaintText = member.get($translate.instant("CHIEF_COMPLAINT_TEXT_KEY"));
+          }
+          if (member && member.has($translate.instant("SIGN_SYMPTOM_DURATION_KEY"))) {
+              symptomDuration = member.get($translate.instant("SIGN_SYMPTOM_DURATION_KEY"));
+          }
+          if (member && member.has($translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY"))) {
+              durationUnit = member.get($translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY"));
+          }
+      });
+      return getChiefComplaintDisplayValue(chiefComplaint, chiefComplaintText, symptomDuration, durationUnit, $translate);
+  };
+
+  var getGroupMemberValue = function (observation, $translate) {
+      const chiefComplaintCoded = $translate.instant("CHIEF_COMPLAINT_CODED_KEY");
+      const chiefComplaintText = $translate.instant("CHIEF_COMPLAINT_TEXT_KEY");
+      const symptomDuration = $translate.instant("SIGN_SYMPTOM_DURATION_KEY");
+      const durationUnit = $translate.instant("CHIEF_COMPLAINT_DURATION_UNIT_KEY");
+      if (typeof observation.concept === "object" && observation.concept.name === chiefComplaintCoded) {
+          if (observation.value.name === $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
+              return new Map().set(chiefComplaintCoded, observation.value.name);
+          }
+          return new Map().set(chiefComplaintCoded, getObservationDisplayValue(observation));
+      }
+      if (typeof observation.concept === "object" && observation.concept.name === chiefComplaintText) {
+          return new Map().set(chiefComplaintText, getObservationDisplayValue(observation));
+      }
+      if (typeof observation.concept === "object" && observation.concept.name === symptomDuration) {
+          return new Map().set(symptomDuration, getObservationDisplayValue(observation));
+      }
+      if (typeof observation.concept === "object" && observation.concept.name === durationUnit) {
+          return new Map().set(durationUnit, getObservationDisplayValue(observation));
+      }
+  };
+
+  var getChiefComplaintDisplayValue = function (chiefComplaint, chiefComplaintText, symptomDuration, durationUnit, $translate) {
+      if (chiefComplaint !== $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
+          return $translate.instant("CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: chiefComplaint, duration: symptomDuration, unit: durationUnit});
+      } else {
+          return $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: chiefComplaint, chiefComplaintText: chiefComplaintText, duration: symptomDuration, unit: durationUnit});
+      }
+  };
+
+  var getDurationDisplayValue = function (chiefComplaint, duration, $translate) {
+      var durationForDisplay = Bahmni.Common.Util.DateUtil.convertToUnits(duration.value);
+      if (durationForDisplay["value"] && durationForDisplay["unitName"]) {
+          return getChiefComplaintDisplayValue(chiefComplaint, durationForDisplay["value"], durationForDisplay["unitName"], $translate);
+      }
+      return "";
+  };
+
+  this.getGridObservationDisplayValue = function (observation, $translate) {
+      var memberValues = _.compact(_.map(observation.groupMembers, function (member) { return getGroupMemberValue(member, $translate); }));
+      return getObservationValue(memberValues, $translate);
+  };
+
+  var getLabel = function (concept) {
+      var mappedConcept = conceptMapper.map(concept);
+      return mappedConcept.shortName || mappedConcept.name;
+  };
 };

--- a/ui/app/common/displaycontrols/bacteriologyresults/directives/bacteriologyResultsControl.js
+++ b/ui/app/common/displaycontrols/bacteriologyresults/directives/bacteriologyResultsControl.js
@@ -47,7 +47,7 @@ angular.module('bahmni.common.displaycontrol.bacteriologyresults')
                         var conceptsConfig = appService.getAppDescriptor().getConfigValue("conceptSetUI") || {};
                         var dontSortByObsDateTime = true;
                         _.forEach($scope.observations, function (observation) {
-                            $scope.specimens.push(specimenMapper.mapObservationToSpecimen(observation, $scope.allSamples, conceptsConfig, dontSortByObsDateTime));
+                            $scope.specimens.push(specimenMapper.mapObservationToSpecimen(observation, $scope.allSamples, conceptsConfig, dontSortByObsDateTime, $translate));
                         });
                     } else {
                         $scope.specimens = [];

--- a/ui/app/common/obs/mappers/observationMapper.js
+++ b/ui/app/common/obs/mappers/observationMapper.js
@@ -18,7 +18,15 @@ Bahmni.Common.Obs.ObservationMapper = function () {
         $.each(bahmniObservations, function (i, bahmniObservation) {
             var conceptConfig = bahmniObservation.formFieldPath ? [] : allConceptsConfig[bahmniObservation.concept.name] || [];
             var observation = new Bahmni.Common.Obs.Observation(bahmniObservation, conceptConfig, $translate);
-            if (observation.groupMembers && observation.groupMembers.length >= 0) {
+            if (observation.groupMembers && observation.groupMembers.length >= 0 && observation.concept.name === $translate.instant("CHIEF_COMPLAINT_DATA_CONCEPT_NAME_KEY")) {
+                if (observation.groupMembers[0].value.name !== $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY")) {
+                    observation.value = $translate.instant("CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: observation.groupMembers[0].value.name, duration: observation.groupMembers[1].value, unit: observation.groupMembers[2].value.name});
+                } else {
+                    observation.value = $translate.instant("CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY", {chiefComplaint: observation.groupMembers[0].value.name, chiefComplaintText: observation.groupMembers[1].value, duration: observation.groupMembers[2].value, unit: observation.groupMembers[3].value.name});
+                }
+                observation.groupMembers = [];
+            }
+            if (observation.groupMembers && observation.groupMembers.length >= 0 && observation.concept.name !== $translate.instant("CHIEF_COMPLAINT_DATA_CONCEPT_NAME_KEY")) {
                 observation.groupMembers = mapObservations(observation.groupMembers, allConceptsConfig, dontSortByObsDateTime, $translate);
             }
             mappedObservations.push(observation);

--- a/ui/app/i18n/clinical/locale_en.json
+++ b/ui/app/i18n/clinical/locale_en.json
@@ -371,5 +371,6 @@
   "SHARE_PRESCRIPTION_MAIL_CONTENT": "Hi #recipientName,\nThanks for visiting #locationName on #visitDate. Your prescription is attached with this email. Wish you a speedy recovery.\nThanks.\n#locationName\n#locationAddress",
   "CHIEF_COMPLAINT_CODED_KEY": "Chief Complaint Coded",
   "SIGN_SYMPTOM_DURATION_KEY": "Sign/symptom duration",
-  "CHIEF_COMPLAINT_DURATION_UNIT_KEY": "Chief Complaint Duration"
+  "CHIEF_COMPLAINT_DURATION_UNIT_KEY": "Chief Complaint Duration",
+  "CHIEF_COMPLAINT_TEXT_KEY": "Chief complaint (text)"
 }

--- a/ui/test/unit/clinical/mappers/specimenMapper.spec.js
+++ b/ui/test/unit/clinical/mappers/specimenMapper.spec.js
@@ -2,8 +2,26 @@
 
 describe("SpecimenMapper", function () {
     var specimenMapper = new Bahmni.Clinical.SpecimenMapper();
+    var translate;
 
     describe("mapObservationToSpecimen", function () {
+
+        var translatedMessages = {
+            "CHIEF_COMPLAINT_DATA_CONCEPT_NAME_KEY": "Chief Complaint Record",
+            "CHIEF_COMPLAINT_CODED_KEY": "Chief Complaint Coded",
+            "SIGN_SYMPTOM_DURATION_KEY": "Sign/symptom duration",
+            "CHIEF_COMPLAINT_DURATION_UNIT_KEY": "Chief Complaint Duration",
+            "CHIEF_COMPLAINT_TEXT_KEY": "Chief complaint (text)",
+            "CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY": "Other generic",
+            "CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY": "{{chiefComplaint}} ({{chiefComplaintText}}) since {{duration}} {{unit}}",
+            "CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY": "{{chiefComplaint}} since {{duration}} {{unit}}"
+        };
+    
+        var translate = jasmine.createSpyObj('$translate', ['instant']);
+        translate.instant.and.callFake(function (key) {
+            return translatedMessages[key];
+        });
+
         it("should map observation to specimen object", function () {
             var observationData = {
                 identifier: "138",
@@ -26,7 +44,7 @@ describe("SpecimenMapper", function () {
                 }
             };
 
-            var specimen = specimenMapper.mapObservationToSpecimen(observationData, undefined, {});
+            var specimen = specimenMapper.mapObservationToSpecimen(observationData, undefined, {}, null, translate);
             expect(specimen.specimenId).toBe(observationData.identifier);
             expect(specimen.specimenSource).toBe(observationData.type.name);
             expect(specimen.specimenCollectionDate).toBe(specimen.dateCollected);
@@ -74,7 +92,7 @@ describe("SpecimenMapper", function () {
                 }
             };
 
-            var specimen = specimenMapper.mapObservationToSpecimen(observationData, undefined, {}, true);
+            var specimen = specimenMapper.mapObservationToSpecimen(observationData, undefined, {}, true, translate);
             expect(specimen.specimenId).toBe(observationData.identifier);
             expect(specimen.specimenSource).toBe(observationData.type.name);
             expect(specimen.specimenCollectionDate).toBe(specimen.dateCollected);

--- a/ui/test/unit/common/obs/observationMapper.spec.js
+++ b/ui/test/unit/common/obs/observationMapper.spec.js
@@ -2,8 +2,25 @@
 
 describe("ObservationMapper", function () {
     var ObservationMapper = Bahmni.Common.Obs.ObservationMapper;
+    var translate;
+    var translatedMessages = {
+        "CHIEF_COMPLAINT_DATA_CONCEPT_NAME_KEY": "Chief Complaint Record",
+        "CHIEF_COMPLAINT_CODED_KEY": "Chief Complaint Coded",
+        "SIGN_SYMPTOM_DURATION_KEY": "Sign/symptom duration",
+        "CHIEF_COMPLAINT_DURATION_UNIT_KEY": "Chief Complaint Duration",
+        "CHIEF_COMPLAINT_TEXT_KEY": "Chief complaint (text)",
+        "CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_KEY": "Other generic",
+        "CHIEF_COMPLAINT_DATA_OTHER_CONCEPT_TEMPLATE_KEY": "{{chiefComplaint}} ({{chiefComplaintText}}) since {{duration}} {{unit}}",
+        "CHIEF_COMPLAINT_DATA_WITHOUT_OTHER_CONCEPT_TEMPLATE_KEY": "{{chiefComplaint}} since {{duration}} {{unit}}"
+    };
+
+    translate = jasmine.createSpyObj('$translate', ['instant']);
+    translate.instant.and.callFake(function (key) {
+        return translatedMessages[key];
+    });
 
     describe("should map observation", function () {
+
         it("should map openmrs observation types - coded, boolean", function () {
             var bahmniObservations = [
                 {
@@ -22,7 +39,7 @@ describe("ObservationMapper", function () {
                     ],
                     "concept": {"shortName": null, "name": "Chemotherapy", "set": true, "units": null, "conceptClass": "Misc", "dataType": "N/A"} }
             ];
-            var mappedObservation = new ObservationMapper().map(bahmniObservations, {});
+            var mappedObservation = new ObservationMapper().map(bahmniObservations, {}, null, translate);
             expect(mappedObservation.length).toBe(1);
             expect(mappedObservation[0] instanceof Bahmni.Common.Obs.Observation).toBe(true);
             expect(mappedObservation[0].groupMembers.length).toBe(2);
@@ -47,7 +64,7 @@ describe("ObservationMapper", function () {
                     "concept": {"shortName": null, "uuid": "134dc2f6-e045-4927-bf47-d18984a536b9", "name": "Histopathology", "conceptClass": "Misc", "dataType": "N/A"}
                 }
             ];
-            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Pathologic Diagnosis": {"multiSelect": true}});
+            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Pathologic Diagnosis": {"multiSelect": true}}, null, translate);
             expect(mappedObservation.length).toBe(1);
             expect(mappedObservation[0] instanceof Bahmni.Common.Obs.Observation).toBe(true);
             expect(mappedObservation[0].groupMembers.length).toBe(1);
@@ -77,7 +94,7 @@ describe("ObservationMapper", function () {
                     ] 
                 }
             ];
-            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Pathologic Diagnosis": {"multiSelect": true}});
+            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Pathologic Diagnosis": {"multiSelect": true}}, null, translate);
             expect(mappedObservation.length).toBe(1);
             expect(mappedObservation[0] instanceof Bahmni.Common.Obs.Observation).toBe(true);
             expect(mappedObservation[0].groupMembers.length).toBe(1);
@@ -104,7 +121,7 @@ describe("ObservationMapper", function () {
                     "concept": {"shortName": null, "name": "Receptor Status", "set": true, "units": null, "conceptClass": "Misc", "dataType": "N/A"}}
 
             ];
-            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Receptor Status": {"grid": true}});
+            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Receptor Status": {"grid": true}}, null, translate);
             expect(mappedObservation.length).toBe(1);
             expect(mappedObservation[0] instanceof Bahmni.Common.Obs.GridObservation).toBe(true);
             expect(mappedObservation[0].value).toBe("ER-, PR+");
@@ -183,7 +200,7 @@ describe("ObservationMapper", function () {
                     "formFieldPath": "form2.1/2-0"
                 }
             ];
-            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Pathologic Diagnosis": {"multiSelect": true}});
+            var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Pathologic Diagnosis": {"multiSelect": true}}, null, translate);
             expect(mappedObservation.length).toBe(3);
             expect(mappedObservation[0] instanceof Bahmni.Common.Obs.Observation).toBe(true);
             expect(mappedObservation[0].groupMembers.length).toBe(0);
@@ -254,8 +271,7 @@ describe("ObservationMapper", function () {
                 "formFieldPath": "form2.1/2-0"
             }
         ];
-        var mappedObservation = new ObservationMapper().map(bahmniObservations,
-            {"Pathologic Diagnosis": {"multiSelect": true}});
+        var mappedObservation = new ObservationMapper().map(bahmniObservations, {"Pathologic Diagnosis": {"multiSelect": true}}, null, translate);
         expect(mappedObservation.length).toBe(3);
         expect(mappedObservation[0] instanceof Bahmni.Common.Obs.MultiSelectObservation).toBe(true);
         expect(mappedObservation[0].groupMembers.length).toBe(2);


### PR DESCRIPTION
Trello -> [GOK-277](https://trello.com/c/CXf6AYuC)

The observations added under "Chief Complaint Record" will be presented in the following formats:

1. For a chief complaint with a coded value other than "Other generic," the observations will appear as a single string: 
`{{chiefComplaint}} since {{duration}} {{unit}}`
2. For a chief complaint with a coded value "Other generic," the observations will be displayed as:
`{{chiefComplaint}} ({{chiefComplaintText}}) since {{duration}} {{unit}}`

Please note that this approach is a temporary solution to address the issue at hand. The code responsible for observation mapping requires some refactoring, which is a time-consuming process and must be rigorously tested. As an interim measure, I will push the temporary fix to the GitHub repository - Bahmni-HWC/openmrs-module-bahmniapps. Once the code has been refactored and thoroughly tested within the product, we can proceed with a synchronization of the changes.

<div style="display: flex;">
  <img width="400" src="https://github.com/Bahmni-HWC/openmrs-module-bahmniapps/assets/121226043/2837b579-2b30-4426-8f58-444c12a53d12">
  <img width="400" src="https://github.com/Bahmni-HWC/openmrs-module-bahmniapps/assets/121226043/6dd7d8f5-eebb-4645-a7d2-ad2cbf6da635">
  <img width="400" src="https://github.com/Bahmni-HWC/openmrs-module-bahmniapps/assets/121226043/5d5dca17-5559-4132-9632-c4df297553df">
  <img width="400" src="https://github.com/Bahmni-HWC/openmrs-module-bahmniapps/assets/121226043/351aacab-8256-4861-8cee-aa8abefb6b96">
    <img width="400" src="https://github.com/Bahmni-HWC/openmrs-module-bahmniapps/assets/121226043/1849478a-8038-49d1-b7bb-64919deb16cf">
 </div>